### PR TITLE
ci: upgrade actions/setup-java to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Java ${{ matrix.java-version }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'oracle'
           java-version: ${{ matrix.java-version }}


### PR DESCRIPTION
## Summary

Upgrades `actions/setup-java` from `v4` to `v5` in `.github/workflows/ci.yml`.

### Rationale
- Resolves GitHub Actions deprecation warning on Node.js runtime for `setup-java@v4`.
- Fully supports Java 25 LTS JDK toolchain caching across Ubuntu, macOS, and Windows runners.
