### PR TITLE
ci: add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,28 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    name: Enable Auto-Merge for Dependabot
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot Metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      # Automatically enable auto-merge on minor and patch updates
+      - name: Enable Auto-Merge
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds an automated Dependabot auto-merge GitHub Actions workflow (`.github/workflows/dependabot-auto-merge.yml`).

### How It Works
1. When Dependabot opens a pull request, the workflow uses `dependabot/fetch-metadata@v2` to inspect the version bump type.
2. For non-breaking updates (`minor` and `patch` version bumps), it queues auto-merge via `gh pr merge --auto --squash`.
3. GitHub will automatically merge the Dependabot PR as soon as the `CI Gatekeeper` required status check succeeds across Linux, macOS, and Windows.
4. Breaking major bumps (`semver-major`) will still require manual review.
