### PR TITLE
ci: configure grouped updates for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      maven-dependencies:
+        patterns:
+          - "*"
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -13,3 +17,7 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      actions-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary of Changes

Configures **Grouped Updates** in `.github/dependabot.yml`.

### 🌟 Key Benefits
- **Bundled PRs:** Groups routine dependency updates into a single weekly PR for Maven dependencies (`maven-dependencies`) and a single weekly PR for GitHub Actions (`actions-dependencies`).
- **Eliminates Rebase Cascades:** Prevents multiple Dependabot PRs from conflicting with each other or creating a sequential rebase waterfall when merging against `main`.
- **Fast Testing:** Runs CI once across all updated dependencies together in a single matrix run.
